### PR TITLE
By default use hawkular client ruby master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ end
 manageiq_plugin "manageiq-providers-ansible_tower" # can't move this down yet, because we can't autoload ManageIQ::Providers::AnsibleTower::Shared
 manageiq_plugin "manageiq-schema"
 
+gem "hawkular-client", :git => "https://github.com/hawkular/hawkular-client-ruby", :branch => "master"
+
 # Unmodified gems
 gem "activerecord-id_regions",        "~>0.2.0"
 gem "activerecord-session_store",     "~>1.1"


### PR DESCRIPTION
To avoid the slowdown of having to release gems while we are doing this change, lets use the hawkular-client-ruby.

@israel-hdez please take a look.